### PR TITLE
fix url when using different apps folder

### DIFF
--- a/js/public/app.js
+++ b/js/public/app.js
@@ -58,7 +58,7 @@ app.controller('WeatherController', ['$scope', '$interval', '$timeout', '$compil
 
 		// timeout functions internal calls cannot be serialized
 		$timeout(function () {
-			var imgPath = OC.generateUrl('/apps/weather').replace('index.php/','');
+			var imgPath = OC.filePath('weather','img','').replace('index.php/','');
 			$scope.owncloudAppImgPath = imgPath;
 			$scope.loadCities();
 		});

--- a/templates/main.php
+++ b/templates/main.php
@@ -48,12 +48,12 @@
 			<a href="http://home.openweathermap.org/users/sign_in" ng-show="cityLoadNeedsAPIKey == true">Click here to get an API key</a>
 		</span>
 	</div>
-	<div id="city-right" ng-show="cityLoadError == '' && currentCity != null" style="background-image: url('{{ owncloudAppImgPath }}/img/{{ currentCity.image }}');">
+	<div id="city-right" ng-show="cityLoadError == '' && currentCity != null" style="background-image: url('{{ owncloudAppImgPath }}{{ currentCity.image }}');">
 		<div id="city-weather-panel">
 			<div class="city-name">
 				{{ currentCity.name }}, {{ currentCity.sys.country }}
-				<img ng-show="selectedCityId == homeCity" src="{{ owncloudAppImgPath }}/img/home-pick.png" />
-				<img class="home-icon" ng-click="setHome(selectedCityId);" ng-show="selectedCityId != homeCity" src="{{ owncloudAppImgPath }}/img/home-nopick.png" />
+				<img ng-show="selectedCityId == homeCity" src="{{ owncloudAppImgPath }}home-pick.png" />
+				<img class="home-icon" ng-click="setHome(selectedCityId);" ng-show="selectedCityId != homeCity" src="{{ owncloudAppImgPath }}home-nopick.png" />
 			</div>
 			<div class="city-current-temp">{{ currentCity.main.temp }}{{ metricRepresentation }}</div>
 			<div class="city-current-pressure">Pressure: {{ currentCity.main.pressure }} hpa</div>


### PR DESCRIPTION
Using `OC.filePath` allows to place the app in an apps-repos folder because it correctly resolves the right app folder.